### PR TITLE
Remove path & query encoding and ading unit tests

### DIFF
--- a/lib/azure/core/service.rb
+++ b/lib/azure/core/service.rb
@@ -37,8 +37,7 @@ module Azure
       end
 
       def generate_uri(path='', query={})
-        enconded_file_uri_string = URI.encode(File.join(host, path))
-        uri = URI.parse(enconded_file_uri_string)
+        uri = URI.parse(File.join(host, path))
         uri.query = URI.encode_www_form(query) unless query == nil or query.empty?
         uri
       end

--- a/test/unit/core/service_test.rb
+++ b/test/unit/core/service_test.rb
@@ -1,0 +1,73 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#--------------------------------------------------------------------------
+require 'test_helper'
+require 'azure/core'
+
+describe 'Azure core service' do
+  subject do
+    Azure::Core::Service.new
+  end
+
+  it 'generate_uri should return URI instance' do
+    subject.host = 'http://dumyhost.uri'
+    subject.generate_uri.must_be_kind_of ::URI
+    subject.generate_uri.to_s.must_equal 'http://dumyhost.uri/'
+  end
+
+  it 'generate_uri should add path to the url' do
+    subject.generate_uri('resource/entity/').path.must_equal '/resource/entity/'
+  end
+
+  it 'generate_uri should correctly join the path if host url contained a path' do
+    subject.host = 'http://dummy.uri/host/path'
+    subject.generate_uri('resource/entity/').path.must_equal '/host/path/resource/entity/'
+  end
+
+  it 'generate_uri should encode the keys' do
+    subject.generate_uri('', {'key !' => 'value'}).query.must_include 'key+%21=value'
+  end
+
+  it 'generate_uri should encode the values' do
+    subject.generate_uri('', {'key' => 'value !'}).query.must_include 'key=value+%21'
+  end
+
+  it 'generate_uri should set query string to the encoded result' do
+    subject.generate_uri('', {'key' => 'value !', 'key !' => 'value'}).query.must_equal 'key=value+%21&key+%21=value'
+  end
+
+  it 'generate_uri should override the default timeout' do
+    subject.generate_uri('', {'timeout' => 45}).query.must_equal 'timeout=45'
+  end
+
+  it 'generate_uri should not include any query parameters' do
+    subject.generate_uri('', nil).query.must_equal nil
+  end
+
+  it 'generate_uri should not re-encode path with spaces' do
+    subject.host = 'http://dumyhost.uri'
+    encoded_path = 'blob%20name%20with%20spaces'
+    uri = subject.generate_uri(encoded_path, nil)
+    uri.host.must_equal 'dumyhost.uri'
+    uri.path.must_equal '/blob%20name%20with%20spaces'
+  end
+
+  it 'generate_uri should not re-encode path with special characters' do
+    subject.host = 'http://dumyhost.uri'
+    encoded_path = 'host/path/%D1%84%D0%B1%D0%B0%D1%84.jpg'
+    uri = subject.generate_uri(encoded_path, nil)
+    uri.host.must_equal 'dumyhost.uri'
+    uri.path.must_equal '/host/path/%D1%84%D0%B1%D0%B0%D1%84.jpg'
+  end
+end


### PR DESCRIPTION
This is regarding the Issue #[360 ](https://github.com/Azure/azure-sdk-for-ruby/issues/360)where users were uploading file with spaces in name then uploaded file has encodided characters e.g. %20 for space. This is due to the double encoding problem (once in [blob_service.rb:1442](https://github.com/Azure/azure-sdk-for-ruby/blob/master/service_management/azure/lib/azure/blob/blob_service.rb#L1442) and second time in [service.rb:40](https://github.com/Azure/azure-ruby-asm-core/blob/master/lib/azure/core/service.rb#L40)).

Being Azure-asm-core separated into its own [repo ](https://github.com/Azure/azure-ruby-asm-core) and [gem ](https://rubygems.org/gems/azure-core), this PR removed encoding from generate_uri method as [service.rb:40](https://github.com/Azure/azure-ruby-asm-core/blob/master/lib/azure/core/service.rb#L40) should supply encoded path.