### PR TITLE
Return response instead of raising exception when there is a retry filter

### DIFF
--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -44,11 +44,7 @@ module Azure
       end
 
       def should_retry?(response, retry_data)
-        if retry_data[:error].inspect.include?('Error: Retry')
-          true
-        else
-          false
-        end
+        retry_data[:error].inspect.include?('Error: Retry')
       end
     end
 

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #--------------------------------------------------------------------------
+require "azure/core/http/retry_policy"
 require "pathname"
 
 module Azure
@@ -35,6 +36,20 @@ module Azure
 
     def Fixtures.xml?(fixture)
       file?("#{fixture}.xml")
+    end
+    
+    class FixtureRetryPolicy < Azure::Core::Http::RetryPolicy
+      def initialize
+        super &:should_retry?
+      end
+
+      def should_retry?(response, retry_data)
+        if retry_data[:error].inspect.include?('Error: Retry')
+          true
+        else
+          false
+        end
+      end
     end
 
   end

--- a/test/unit/core/http/retry_policy_test.rb
+++ b/test/unit/core/http/retry_policy_test.rb
@@ -20,4 +20,14 @@ describe Azure::Core::Http::RetryPolicy do
     retry_policy = Azure::Core::Http::RetryPolicy.new do |a,b| true end
     retry_policy.should_retry?(nil, nil).must_equal true
   end
+  
+  it 'uses retry policy as retry logic with expected error' do
+    retry_policy = Azure::Core::FixtureRetryPolicy.new
+    retry_policy.should_retry?(nil, {:error => 'Error: Retry'}).must_equal true
+  end
+
+  it 'uses retry policy as retry logic with unexpect error' do
+    retry_policy = Azure::Core::FixtureRetryPolicy.new
+    retry_policy.should_retry?(nil, {:error => 'Error: No retry'}).must_equal false
+  end
 end


### PR DESCRIPTION
In retry_policy.rb, the signature of `should_retry` is:
     
    def should_retry?(response, retry_data)
If it always raises exception in http_request.rb when the request doesn't succeed, there is no chance to get the response for the retry filter.

In this change, it checks whether there is a retry filter (derived from `Azure::Core::Http::RetryPolicy`). If so, the response will be pass to `should_retry?`, otherwise it will raise exception as before.