### PR TITLE
Updating signature generation due to SAS issue

### DIFF
--- a/lib/azure/core/auth/signer.rb
+++ b/lib/azure/core/auth/signer.rb
@@ -32,7 +32,7 @@ module Azure
             raise ArgumentError, 'Signing key must be provided'
           end
 
-          @access_key = Base64.strict_decode64(access_key)
+          @access_key = access_key
         end
 
         # Generate an HMAC signature.
@@ -41,7 +41,7 @@ module Azure
         #
         # @return [String] a Base64 String signed with HMAC.
         def sign(body)
-          signed = OpenSSL::HMAC.digest('sha256', access_key, body)
+          signed = OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha256'), access_key, body)
           Base64.strict_encode64(signed)
         end
 

--- a/test/unit/core/auth/shared_key_lite_test.rb
+++ b/test/unit/core/auth/shared_key_lite_test.rb
@@ -35,11 +35,11 @@ describe Azure::Core::Auth::SharedKeyLite do
 
   describe 'sign' do
     it 'creates a signature from the provided HTTP method, uri, and reduced set of standard headers' do
-      subject.sign(verb, uri, headers).must_equal 'account-name:vVFnj/+27JFABZgpt5H8g/JVU2HuWFnjv5aeUIxQvBE='
+      subject.sign(verb, uri, headers).must_equal 'account-name:X0xhbX2F3xnhxJqjLToYAiBrDbbK02yLCOFqKv0KHts='
     end
 
     it 'ignores standard headers other than Content-MD5, Content-Type, and Date' do
-      subject.sign(verb, uri, headers.merge({'Content-Encoding' => 'foo'})).must_equal 'account-name:vVFnj/+27JFABZgpt5H8g/JVU2HuWFnjv5aeUIxQvBE='
+      subject.sign(verb, uri, headers.merge({'Content-Encoding' => 'foo'})).must_equal 'account-name:X0xhbX2F3xnhxJqjLToYAiBrDbbK02yLCOFqKv0KHts='
     end
 
     it 'throws IndexError when there is no Date header' do

--- a/test/unit/core/auth/shared_key_test.rb
+++ b/test/unit/core/auth/shared_key_test.rb
@@ -16,7 +16,7 @@ require 'test_helper'
 require 'azure/core/auth/shared_key'
 
 describe Azure::Core::Auth::SharedKey do
-  subject { Azure::Core::Auth::SharedKey.new 'account-name', 'YWNjZXNzLWtleQ==' }
+  subject { Azure::Core::Auth::SharedKey.new 'account-name', 'access-key' }
 
   let(:verb) { 'POST' }
   let(:uri) { URI.parse 'http://dummy.uri/resource' }

--- a/test/unit/core/auth/signer_test.rb
+++ b/test/unit/core/auth/signer_test.rb
@@ -16,11 +16,7 @@ require "test_helper"
 require "azure/core/auth/signer"
 
 describe Azure::Core::Auth::Signer do
-  subject { Azure::Core::Auth::Signer.new "YWNjZXNzLWtleQ==" }
-
-  it "decodes the base64 encoded access_key" do
-    subject.access_key.must_equal "access-key"
-  end
+  subject { Azure::Core::Auth::Signer.new "access-key" }
 
   describe "sign" do
     it "creates a signature for the body, as a base64 encoded string, which represents a HMAC hash using the access_key" do


### PR DESCRIPTION
Updating how we deal with access_key for signing, in order to address issue [https://github.com/Azure/azure-sdk-for-ruby/issues/232](https://github.com/Azure/azure-sdk-for-ruby/issues/232).

I'll be sending a pull request in azure-sdk-for-ruby repo to add a test for service bus using SAS:
```ruby
  describe "when using SAS" do
    before do
      VCR.insert_cassette "service_bus/#{name}"
      sb_host = "https://#{Azure.sb_namespace}.servicebus.windows.net"
      signer = Azure::ServiceBus::Auth::SharedAccessSigner.new(Azure.sb_sas_key_name, Azure.sb_sas_key)
      @servicebus = Azure::ServiceBus::ServiceBusService.new(sb_host, { signer: signer })
      @servicebus.create_queue queue_name
    end

    after do
      response = @servicebus.delete_queue queue_name
      response.must_equal nil
      VCR.eject_cassette
    end

    it "should be able to send a message with SAS to a queue" do
      msg = Azure::ServiceBus::BrokeredMessage.new("some text") do |m|
        m.to = "yo"
      end
      res = @servicebus.send_queue_message(queue_name, msg)
      res.must_be_nil
      q = @servicebus.get_queue(queue_name)
      q.message_count.must_equal 1
    end
  end
```