### PR TITLE
Revert the breaking changes and reconsider them in v0.2

### DIFF
--- a/lib/azure/core/auth/shared_key.rb
+++ b/lib/azure/core/auth/shared_key.rb
@@ -24,9 +24,11 @@ module Azure
 
         # Initialize the Signer.
         #
-        # @param account_name [String] The account name.
-        # @param access_key   [String] The access_key encoded in Base64.
-        def initialize(account_name, access_key)
+        # @param account_name [String] The account name. Defaults to the one in the
+        #                global configuration.
+        # @param access_key   [String] The access_key encoded in Base64. Defaults to the
+        #                one in the global configuration.
+        def initialize(account_name=Azure.storage_account_name, access_key=Azure.storage_access_key)
           @account_name = account_name
           super(access_key)
         end

--- a/lib/azure/core/auth/signer.rb
+++ b/lib/azure/core/auth/signer.rb
@@ -32,7 +32,7 @@ module Azure
             raise ArgumentError, 'Signing key must be provided'
           end
 
-          @access_key = access_key
+          @access_key = Base64.strict_decode64(access_key)
         end
 
         # Generate an HMAC signature.
@@ -41,7 +41,7 @@ module Azure
         #
         # @return [String] a Base64 String signed with HMAC.
         def sign(body)
-          signed = OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha256'), access_key, body)
+          signed = OpenSSL::HMAC.digest('sha256', access_key, body)
           Base64.strict_encode64(signed)
         end
 

--- a/lib/azure/core/signed_service.rb
+++ b/lib/azure/core/signed_service.rb
@@ -24,7 +24,7 @@ module Azure
       # Create a new instance of the SignedService
       #
       # @param signer         [Azure::Core::Auth::Signer]. An implementation of Signer used for signing requests. (optional, Default=Azure::Core::Auth::SharedKey.new)
-      # @param account_name   [String] The account name (optional, Default=Azure.storage_account_name)
+      # @param account_name   [String] The account name (optional, Default=Azure.config.storage_account_name)
       # @param options        [Hash] options
       def initialize(signer=nil, account_name=nil, options={})
         super('', options)

--- a/test/unit/core/auth/shared_key_lite_test.rb
+++ b/test/unit/core/auth/shared_key_lite_test.rb
@@ -35,11 +35,11 @@ describe Azure::Core::Auth::SharedKeyLite do
 
   describe 'sign' do
     it 'creates a signature from the provided HTTP method, uri, and reduced set of standard headers' do
-      subject.sign(verb, uri, headers).must_equal 'account-name:X0xhbX2F3xnhxJqjLToYAiBrDbbK02yLCOFqKv0KHts='
+      subject.sign(verb, uri, headers).must_equal 'account-name:vVFnj/+27JFABZgpt5H8g/JVU2HuWFnjv5aeUIxQvBE='
     end
 
     it 'ignores standard headers other than Content-MD5, Content-Type, and Date' do
-      subject.sign(verb, uri, headers.merge({'Content-Encoding' => 'foo'})).must_equal 'account-name:X0xhbX2F3xnhxJqjLToYAiBrDbbK02yLCOFqKv0KHts='
+      subject.sign(verb, uri, headers.merge({'Content-Encoding' => 'foo'})).must_equal 'account-name:vVFnj/+27JFABZgpt5H8g/JVU2HuWFnjv5aeUIxQvBE='
     end
 
     it 'throws IndexError when there is no Date header' do

--- a/test/unit/core/auth/shared_key_test.rb
+++ b/test/unit/core/auth/shared_key_test.rb
@@ -16,7 +16,7 @@ require 'test_helper'
 require 'azure/core/auth/shared_key'
 
 describe Azure::Core::Auth::SharedKey do
-  subject { Azure::Core::Auth::SharedKey.new 'account-name', 'access-key' }
+  subject { Azure::Core::Auth::SharedKey.new 'account-name', 'YWNjZXNzLWtleQ==' }
 
   let(:verb) { 'POST' }
   let(:uri) { URI.parse 'http://dummy.uri/resource' }

--- a/test/unit/core/auth/signer_test.rb
+++ b/test/unit/core/auth/signer_test.rb
@@ -16,7 +16,11 @@ require "test_helper"
 require "azure/core/auth/signer"
 
 describe Azure::Core::Auth::Signer do
-  subject { Azure::Core::Auth::Signer.new "access-key" }
+  subject { Azure::Core::Auth::Signer.new "YWNjZXNzLWtleQ==" }
+
+  it "decodes the base64 encoded access_key" do
+    subject.access_key.must_equal "access-key"
+  end
 
   describe "sign" do
     it "creates a signature for the body, as a base64 encoded string, which represents a HMAC hash using the access_key" do


### PR DESCRIPTION
1. Reverts commit 7bb5b4b which breaks the signer for authentication.
2. Reverts commit efaf612 which breaks the default value.