### PR TITLE
Adding autoload for auth files

### DIFF
--- a/lib/azure/core.rb
+++ b/lib/azure/core.rb
@@ -27,6 +27,12 @@ module Azure
     autoload :FilteredService,                'azure/core/filtered_service'
     autoload :SignedService,                  'azure/core/signed_service'
     autoload :Default,                        'azure/core/default'
+    module Auth
+      autoload :SharedKey,                    'azure/core/auth/shared_key'
+      autoload :Signer,                       'azure/core/auth/signer'
+      autoload :Authorizer,                   'azure/core/auth/authorizer'
+      autoload :SharedKeyLite,                'azure/core/auth/shared_key_lite'
+    end
   end
 
 end


### PR DESCRIPTION
Adding autoload for auth files, so then consuming azure-core (from azure gem for example), they don't need to be required from the caller.