### PR TITLE
Fixed the issue where it throws the HTTP error even there is a retry filter

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+# 2016.10.31 - azure-core gem @version 0.1.6
+* Fixed the issue where it throws the HTTP error even there is a retry filter.
+
 # 2016.9.21 - azure-core gem @version 0.1.5
 * Adding autoload for auth files, to avoid having to require these files from dependent gems [#25](https://github.com/Azure/azure-ruby-asm-core/pull/25)
 

--- a/lib/azure/core/http/http_request.rb
+++ b/lib/azure/core/http/http_request.rb
@@ -96,7 +96,7 @@ module Azure
         def with_filter(filter=nil, &block)
           filter = filter || block
           if filter
-            @has_retry_filter = filter.is_a? Azure::Core::Http::RetryPolicy
+            @has_retry_filter ||= filter.is_a?(Azure::Core::Http::RetryPolicy)
             original_call = self._method(:call)
 
             # support 1.8.7 (define_singleton_method doesn't exist until 1.9.1)

--- a/test/unit/core/filter_service_test.rb
+++ b/test/unit/core/filter_service_test.rb
@@ -12,22 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #--------------------------------------------------------------------------
+require 'test_helper'
+require 'azure/core'
+require "azure/core/http/debug_filter"
+require "azure/core/http/retry_policy"
 
-module Azure
-  module Core
-    class Version
-      MAJOR = 0 unless defined? MAJOR
-      MINOR = 1 unless defined? MINOR
-      UPDATE = 6 unless defined? UPDATE
-      PRE = nil unless defined? PRE
+describe 'Azure core service' do
+  subject do
+    Azure::Core::FilteredService.new
+  end
 
-      class << self
+  it 'works with default' do
+    subject.filters.count.must_equal 0
+  end
 
-        # @return [String]
-        def to_s
-          [MAJOR, MINOR, UPDATE].join('.') + (PRE.nil? ? '' : "-#{PRE}")
-        end
-      end
-    end
+  it 'works with a debug filter' do
+    service = Azure::Core::FilteredService.new
+    service.with_filter Azure::Core::Http::DebugFilter.new
+    service.filters.count.must_equal 1
+  end
+
+  it 'works with retry policy filter' do
+    service = Azure::Core::FilteredService.new
+    service.with_filter Azure::Core::Http::DebugFilter.new
+    service.with_filter Azure::Core::Http::RetryPolicy.new
+    service.filters.count.must_equal 2
   end
 end


### PR DESCRIPTION
The issue is the `@has_retry_filter` of `Azure::Core:Http::HttpRequest` will be overwritten when other filters are added. The change is to keep the value when there is at least one retry filter.
