### PR TITLE
Throw the HTTP error when it is not thrown from the previous filter

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-# 2016.10.31 - azure-core gem @version 0.1.6
+# 2016.11.23 - azure-core gem @version 0.1.6
 * Fixed the issue where it throws the HTTP error even there is a retry filter.
 
 # 2016.9.21 - azure-core gem @version 0.1.5

--- a/lib/azure/core/http/retry_policy.rb
+++ b/lib/azure/core/http/retry_policy.rb
@@ -42,6 +42,8 @@ module Azure
           rescue
             retry_data[:error] = $!
           end while should_retry?(response, retry_data)
+          # Assign the error when HTTP error is not thrown from the previous filter
+          retry_data[:error] = response.error if response && !response.success?
           if retry_data.has_key?(:error)
             raise retry_data[:error]
           else


### PR DESCRIPTION
This change is to keep the behavior consistent with the previous versions.

Details:
1. When we have a retry filter added, the `HttpRequest` will not throw the exception and it will call the retry filter when the HTTP error happens.
2. In the retry filter, it will retry on the failed request according to the policy. When all the retries are completed, we need throw an exception if the response code still indicates a failure, which this change implements. 