### PR TITLE
Security update to nokogiri >= 1.7.1

### DIFF
--- a/azure-core.gemspec
+++ b/azure-core.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('faraday',                 '~> 0.9')
   s.add_runtime_dependency('faraday_middleware',      '~> 0.10')
-  s.add_runtime_dependency('nokogiri',                '~> 1.6')
+  s.add_runtime_dependency('nokogiri',                '~> 1.7')
 
   s.add_development_dependency('dotenv',              '~> 2.0')
   s.add_development_dependency('minitest',            '~> 5')

--- a/azure-core.gemspec
+++ b/azure-core.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('faraday',                 '~> 0.9')
   s.add_runtime_dependency('faraday_middleware',      '~> 0.10')
-  s.add_runtime_dependency('nokogiri',                '~> 1.7')
+  s.add_runtime_dependency('nokogiri',                '~> 1.7.1')
 
   s.add_development_dependency('dotenv',              '~> 2.0')
   s.add_development_dependency('minitest',            '~> 5')


### PR DESCRIPTION
Nokogiri gem contains several vulnerabilities in libxml2 and libxslt.

https://isitvulnerable.com/vulns/50136