### PR TITLE
Fix Travis file to use only one version of Ruby for publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,5 @@ deploy:
   gem: azure-core
   on:
     tags: true
+    condition: "$TRAVIS_RUBY_VERSION == 2.3.0"
     repo: Azure/azure-ruby-asm-core


### PR DESCRIPTION
@veronicagg @vishrutshah @salameer Please review and approve. 

Please refer https://github.com/Azure/azure-sdk-for-ruby/issues/755 for more context.