### PR TITLE
Changed default value of header 'MaxDataServiceVersion' to '3.0;NetFx' And adding support for JSON response error parsing.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 # 2017.08.31 - azure-core gem @version 0.1.12
 * Changed default value of header `MaxDataServiceVersion` to `3.0;NetFx` now that the service is available.
+* `Azure::Core::Http::HTTPError` now can also parse JSON format response body for error type and description.
 
 # 2017.08.18 - azure-core gem @version 0.1.11
 * Changed 'nokogiri' to runtime dependency with version >= 1.6, and added documentation to resolve dependency issue to Readme for users with Ruby version lower than 2.2.0.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+# 2017.08.31 - azure-core gem @version 0.1.12
+* Changed default value of header `MaxDataServiceVersion` to `3.0;NetFx` now that the service is available.
+
 # 2017.08.18 - azure-core gem @version 0.1.11
 * Changed 'nokogiri' to runtime dependency with version >= 1.6, and added documentation to resolve dependency issue to Readme for users with Ruby version lower than 2.2.0.
 

--- a/lib/azure/core/http/http_request.rb
+++ b/lib/azure/core/http/http_request.rb
@@ -121,7 +121,7 @@ module Azure
             def_headers['x-ms-date'] = current_time
             def_headers['x-ms-version'] = '2014-02-14'
             def_headers['DataServiceVersion'] = '1.0;NetFx'
-            def_headers['MaxDataServiceVersion'] = '2.0;NetFx'
+            def_headers['MaxDataServiceVersion'] = '3.0;NetFx'
             def_headers['Content-Type'] = 'application/atom+xml; charset=utf-8'
           end
         end

--- a/lib/azure/core/version.rb
+++ b/lib/azure/core/version.rb
@@ -18,7 +18,7 @@ module Azure
     class Version
       MAJOR = 0 unless defined? MAJOR
       MINOR = 1 unless defined? MINOR
-      UPDATE = 11 unless defined? UPDATE
+      UPDATE = 12 unless defined? UPDATE
       PRE = nil unless defined? PRE
 
       class << self

--- a/test/unit/core/http/http_request_test.rb
+++ b/test/unit/core/http/http_request_test.rb
@@ -167,6 +167,7 @@ describe Azure::Core::Http::HttpRequest do
         res.expects(:success?).returns(false).at_least_once
         res.expects(:status).returns(401).at_least_once
         res.expects(:body).returns(body).at_least_once
+        res.expects(:headers).returns({}).at_least_once
         res
       end
 


### PR DESCRIPTION
The reason this change was made is because azure-storage ruby client library is upgrading service version to 2016-05-31. With the upgrading Atom format of request/response will be abandoned and JSON will be used. For the purpose, data service version should be upgraded according to the storage's doc [here](https://docs.microsoft.com/en-us/rest/api/storageservices/setting-the-odata-data-service-version-headers). This is currently a blocking issue for azure storage's new version. Please take a look.