### PR TITLE
Added the call options in the retry data and can retry with a different URL

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+# 2017.11.10 - azure-core gem @version 0.1.13
+* Added the call options in the retry data.
+* Added the support for retrying a request with a different URL.
+
 # 2017.08.31 - azure-core gem @version 0.1.12
 * Changed default value of header `MaxDataServiceVersion` to `3.0;NetFx` now that the service is available.
 * `Azure::Core::Http::HTTPError` now can also parse JSON format response body for error type and description.

--- a/lib/azure/core/filtered_service.rb
+++ b/lib/azure/core/filtered_service.rb
@@ -30,9 +30,9 @@ module Azure
 
       attr_accessor :filters
 
-      def call(method, uri, body=nil, headers=nil)
+      def call(method, uri, body=nil, headers=nil, options={})
         super(method, uri, body, headers) do |request|
-          filters.reverse.each { |filter| request.with_filter filter } if filters
+          filters.reverse.each { |filter| request.with_filter filter, options } if filters
         end
       end
 

--- a/lib/azure/core/signed_service.rb
+++ b/lib/azure/core/signed_service.rb
@@ -37,8 +37,8 @@ module Azure
       attr_accessor :account_name
       attr_accessor :signer
 
-      def call(method, uri, body=nil, headers=nil)
-        super(method, uri, body, headers)
+      def call(method, uri, body=nil, headers=nil, options={})
+        super(method, uri, body, headers, options)
       end
     end
   end

--- a/lib/azure/core/version.rb
+++ b/lib/azure/core/version.rb
@@ -18,7 +18,7 @@ module Azure
     class Version
       MAJOR = 0 unless defined? MAJOR
       MINOR = 1 unless defined? MINOR
-      UPDATE = 12 unless defined? UPDATE
+      UPDATE = 13 unless defined? UPDATE
       PRE = nil unless defined? PRE
 
       class << self

--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -48,5 +48,18 @@ module Azure
       end
     end
 
+    class NewUriRetryPolicy < Azure::Core::Http::RetryPolicy
+      def initialize
+        @count = 1
+        super &:should_retry?
+      end
+
+      def should_retry?(response, retry_data)
+        retry_data[:uri] = URI.parse "http://bar.com"
+        @count = @count - 1
+        @count >= 0
+      end
+    end
+
   end
 end

--- a/test/unit/core/http/retry_policy_test.rb
+++ b/test/unit/core/http/retry_policy_test.rb
@@ -30,4 +30,24 @@ describe Azure::Core::Http::RetryPolicy do
     retry_policy = Azure::Core::FixtureRetryPolicy.new
     retry_policy.should_retry?(nil, {:error => 'Error: No retry'}).must_equal false
   end
+
+  describe "NewUriRetryPolicy retries with a new URL" do
+    subject { Azure::Core::NewUriRetryPolicy.new }
+
+    let(:verb) { :put }
+    let(:uri) { URI.parse "http://foo.com" }
+    let(:new_uri) { URI.parse "http://bar.com" }
+    let(:request) { Azure::Core::Http::HttpRequest.new verb, uri, {} }
+    let(:response) { Azure::Core::Http::HttpResponse.new nil, uri }
+
+    before {
+      request.stubs(:call).returns(response)
+      response.stubs(:success?).returns(true)
+    }
+
+    it "retries with a new URL" do
+      subject.call request, request
+      request.uri.must_equal new_uri
+    end
+  end
 end


### PR DESCRIPTION
* Added the call options in the retry data.
* Added the support for retrying a request with a different URL.

This change added the call options in the retry data, thus the retry policy can determine whether retry the request on the secondary endpoint. If a URL is returned in the retry data, the next request will be sent to the new URL. 

I've verified it with `azure-storage`.

@veronicagg, @sarangan12, @katmsft, would you please take a look? Thanks.