### PR TITLE
Fixed bug of re-throwing previously stored response error in retry_policy.rb

### DIFF
--- a/lib/azure/core/http/retry_policy.rb
+++ b/lib/azure/core/http/retry_policy.rb
@@ -47,8 +47,8 @@ module Azure
             @retry_data[:error] = $!
           end while should_retry?(response, @retry_data)
           # Assign the error when HTTP error is not thrown from the previous filter
-          @retry_data[:error] = response.error if response && !response.success?
-          if @retry_data.has_key?(:error)
+          if response && !response.success?
+            @retry_data[:error] = response.error
             raise @retry_data[:error]
           else
             response


### PR DESCRIPTION
The 'retry_policy.rb' file was re-throwing error responses because it has a variable called @retry_data that stores error responses. When the same object is used to make another call, even if the response is positive, since @retry_data has error response stored in it from the previous call, it throws that error again.
This pull request contains code to fix that bug.