### PR TITLE
Initialize retry_data for each request

### DIFF
--- a/lib/azure/core/http/retry_policy.rb
+++ b/lib/azure/core/http/retry_policy.rb
@@ -24,6 +24,7 @@ module Azure
 
         def initialize(&block)
           @block = block
+          @retry_data = {}
         end
 
         attr_accessor :retry_data
@@ -36,7 +37,7 @@ module Azure
         # _next - HttpFilter. The next filter in the pipeline
         def call(req, _next)
           response = nil
-          retry_data = {}
+          retry_data = @retry_data.dup
           begin
             # URI could change in the retry, e.g. secondary endpoint
             unless retry_data[:uri].nil?


### PR DESCRIPTION
I got a timeout error for ssl connection, but never retry even if RetryPolicy enabled.

```ruby
azure_client = Azure::Storage::Client.create(storage_account_name: "xxx",
                                             storage_access_key: "xxx")
azure_client.storage_blob_host = "https://xxx.blob.core.windows.net"
@blob_client = azure_client.blob_client
@blob_client.with_filter(Azure::Storage::Core::Filter::ExponentialRetryPolicyFilter.new)
```

I set blob_client as above and I used it for uploading many files (over 400 files, it took over 2 minutes). 
Then AzureBlob returns timeout error like `Errno::ETIMEDOUT: Failed to open TCP connection to xxx.blob.core.windows.net:443 (Connection timed out - connect(2) for "xxx.blob.core.windows.net" port 443)`.
I expected retry the request but never retried it, because `retry_data[:count]` was already over 400 which exceeded `DEFAULT_RETRY_COUNT = 3`.

So I fixed `retry_data` in `Azure::Core::Http::RetryPolicy` to refresh each request.