### PR TITLE
add an option to specify retry exceptions

### DIFF
--- a/lib/azure/core/http/retry_policy.rb
+++ b/lib/azure/core/http/retry_policy.rb
@@ -23,8 +23,9 @@ module Azure
       class RetryPolicy < HttpFilter
 
         def initialize(options = {}, &block)
-          @retry_exceptions = options[:retry_exceptions] || [::StandardError]
-          @retry_exceptions = [@retry_exceptions] unless @retry_exceptions.is_a?(Array)
+          @retry_exceptions = Array(options[:retry_exceptions])
+          @retry_exceptions.select! { |e| e.ancestors.include?(::Exception) }
+          @retry_exceptions << ::StandardError unless @retry_exceptions.include?(::StandardError)
           @block = block
           @retry_data = {}
         end


### PR DESCRIPTION
It enables to specify retry-able exceptions not only StandardError.

`Azure::Storage::Core::Filter::RetryPolicyFilter` of `azure-storage` gem has retry feature for timeout error ([here](https://github.com/Azure/azure-storage-ruby/blob/v0.15.0/lib/azure/storage/core/filter/retry_filter.rb#L114)), but it cannot rescue such as `Errno::ETIMEDOUT` and `Timeout::Error` because it rescues only `StandardError`.

So, I added an option to specify retry-able exceptions.