### PR TITLE
Permit using a Tempfile as an HTTP request body

### DIFF
--- a/lib/azure/core/http/http_request.rb
+++ b/lib/azure/core/http/http_request.rb
@@ -47,7 +47,7 @@ module Azure
         # Azure client which contains configuration context and http agents
         # @return [Azure::Client]
         attr_accessor :client
-        
+
         # The http filter
         attr_accessor :has_retry_filter
 
@@ -102,7 +102,7 @@ module Azure
             is_retry_policy = filter.is_a?(Azure::Core::Http::RetryPolicy)
             filter.retry_data[:request_options] = options if is_retry_policy
             @has_retry_filter ||= is_retry_policy
-            
+
             original_call = self._method(:call)
 
             # support 1.8.7 (define_singleton_method doesn't exist until 1.9.1)
@@ -159,7 +159,7 @@ module Azure
         def apply_body_headers
           return headers['Content-Length'] = '0' unless body
 
-          return apply_io_headers        if IO === body
+          return apply_io_headers        if IO === body || Tempfile === body
           return apply_string_io_headers if StringIO === body
           return apply_miscellaneous_headers
         end

--- a/test/unit/core/http/http_request_test.rb
+++ b/test/unit/core/http/http_request_test.rb
@@ -81,6 +81,28 @@ describe Azure::Core::Http::HttpRequest do
       end
     end
 
+    describe 'of type Tempfile' do
+      subject do
+        tempfile = Tempfile.open('azure')
+        file = File.open(File.expand_path('../../../../fixtures/files/test.png', __FILE__))
+        IO.copy_stream(file, tempfile)
+
+        Azure::Core::Http::HttpRequest.new(:post, uri, body: tempfile)
+      end
+
+      it 'sets the default Content-Type header' do
+        subject.headers['Content-Type'].must_equal 'application/atom+xml; charset=utf-8'
+      end
+
+      it 'sets the Content-Length header' do
+        subject.headers['Content-Length'].must_equal '4054'
+      end
+
+      it 'sets the Content-MD5 header to a Base64 encoded representation of the MD5 hash of the body' do
+        subject.headers['Content-MD5'].must_equal 'nxTCAVCgA9fOTeV8KY8Pug=='
+      end
+    end
+
     describe ' of type StringIO' do
       subject do
         Azure::Core::Http::HttpRequest.new(:post, uri, body: StringIO.new('<body/>'))


### PR DESCRIPTION
A Tempfile quacks like an IO, so we can handle Tempfiles in exactly the same way we already handle IOs.

Fixes uploading Tempfiles to Azure Storage. See rails/rails#32530.