### PR TITLE
Address deprecations in specs

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,7 +16,7 @@ require 'dotenv'
 Dotenv.load
 
 require 'minitest/autorun'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 require 'minitest/reporters'
 # Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 require 'timecop'

--- a/test/unit/core/service_test.rb
+++ b/test/unit/core/service_test.rb
@@ -52,7 +52,7 @@ describe 'Azure core service' do
   end
 
   it 'generate_uri should not include any query parameters' do
-    subject.generate_uri('', nil).query.must_equal nil
+    subject.generate_uri('', nil).query.must_be_nil
   end
 
   it 'generate_uri should not re-encode path with spaces' do


### PR DESCRIPTION
* Require `mocha/minitest` instead of `mocha/mini_test`
* Prefer `must_be_nil` over `must_equal(nil)`