### PR TITLE
solved the problem, with base64 library.

### DIFF
--- a/lib/azure/core/auth/signer.rb
+++ b/lib/azure/core/auth/signer.rb
@@ -31,8 +31,7 @@ module Azure
           if access_key.nil?
             raise ArgumentError, 'Signing key must be provided'
           end
-
-          @access_key = Base64.strict_decode64(access_key)
+          @access_key = Base64.decode64(access_key)
         end
 
         # Generate an HMAC signature.


### PR DESCRIPTION
base64 is invalid

method strict_decode64  gives errors, needs two arguments, I send the quick solution to this problem
`@access_key = Base64.strict_decode64(access_key)`

changed
`@access_key = Base64.decode64(access_key)`

ruby-2.5.1
ruby-2.4.1
ruby-2.3.1