### PR TITLE
Fix the issue that consecutive spaces in the headers are replaced by one space

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+# 2018.11.20 - azure-core gem @version 0.1.15
+* Fixed the issue that consecutive spaces in the headers are replaced by one space. [Storage #127](https://github.com/Azure/azure-storage-ruby/issues/127)
+
 # 2017.12.28 - azure-core gem @version 0.1.14
 * Added `reason_phrase` as an alternative for HTTP error description if no error details is found in response body 
 * Fixed a bug of re-throwing previously stored response error when it retries. [#51](https://github.com/Azure/azure-ruby-asm-core/issues/51)

--- a/lib/azure/core/auth/shared_key.rb
+++ b/lib/azure/core/auth/shared_key.rb
@@ -96,8 +96,7 @@ module Azure
           headers = headers.map { |k,v| [k.to_s.downcase, v] }
           headers.select! { |k,_| k =~ /^x-ms-/ }
           headers.sort_by! { |(k,_)| k }
-          headers.map! { |k,v| '%s:%s' % [k, v] }
-          headers.map! { |h| h.gsub(/\s+/, ' ') }.join("\n")
+          headers.map! { |k,v| '%s:%s' % [k, v] }.join("\n")
         end
 
         # Calculate the Canonicalized Resource string for a request.

--- a/lib/azure/core/version.rb
+++ b/lib/azure/core/version.rb
@@ -18,7 +18,7 @@ module Azure
     class Version
       MAJOR = 0 unless defined? MAJOR
       MINOR = 1 unless defined? MINOR
-      UPDATE = 14 unless defined? UPDATE
+      UPDATE = 15 unless defined? UPDATE
       PRE = nil unless defined? PRE
 
       class << self

--- a/test/unit/core/auth/shared_key_test.rb
+++ b/test/unit/core/auth/shared_key_test.rb
@@ -34,19 +34,20 @@ describe Azure::Core::Auth::SharedKey do
       'If-Unmodified-Since' => 'foo',
       'Range' => 'foo',
       'x-ms-ImATeapot' => 'teapot',
-      'x-ms-ShortAndStout' => 'True'
+      'x-ms-ShortAndStout' => 'True',
+      'x-ms-reserve-spaces' => 'two  speces'
     }
   end
 
   describe 'sign' do
     it 'creates a signature from the provided HTTP method, uri, and a specific set of standard headers' do
-      subject.sign(verb, uri, headers).must_equal 'account-name:vcdxlDVoE1QvJerkg0ci3Wlnj2Qq8yzlsrkRf5dEU/I='
+      subject.sign(verb, uri, headers).must_equal 'account-name:TVilUAfUwtHIVp+eonglFDXfS5r0/OE0/vVX3GHcaxU='
     end
   end
 
   describe 'canonicalized_headers' do
     it 'creates a canonicalized header string' do
-      subject.canonicalized_headers(headers).must_equal "x-ms-imateapot:teapot\nx-ms-shortandstout:True"
+      subject.canonicalized_headers(headers).must_equal "x-ms-imateapot:teapot\nx-ms-reserve-spaces:two  speces\nx-ms-shortandstout:True"
     end
   end
 


### PR DESCRIPTION
`x-ms-metadata-a: a     b` is trimmed to `x-ms-metadata-a: a b` which makes it a wrong signing string and HTTP error 403 (Forbidden).

This change remove the space trimming logic.