### PR TITLE
Unlock nokogiri version to support Rails 6

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+# 2019.10.01 - azure-core gem @version 0.1.16
+* Fixed the issue that blocks using gem with rails 6. [#67](https://github.com/Azure/azure-ruby-asm-core/issues/67)
+
 # 2018.11.20 - azure-core gem @version 0.1.15
 * Fixed the issue that consecutive spaces in the headers are replaced by one space. [Storage #127](https://github.com/Azure/azure-storage-ruby/issues/127)
 

--- a/azure-core.gemspec
+++ b/azure-core.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('faraday',                 '~> 0.9')
   s.add_runtime_dependency('faraday_middleware',      '~> 0.10')
-  s.add_runtime_dependency('nokogiri',                '~> 1.6')
+  s.add_runtime_dependency('nokogiri',                '>= 1.6')
 
   s.add_development_dependency('dotenv',              '~> 2.0')
   s.add_development_dependency('minitest',            '~> 5')

--- a/lib/azure/core/version.rb
+++ b/lib/azure/core/version.rb
@@ -18,7 +18,7 @@ module Azure
     class Version
       MAJOR = 0 unless defined? MAJOR
       MINOR = 1 unless defined? MINOR
-      UPDATE = 15 unless defined? UPDATE
+      UPDATE = 16 unless defined? UPDATE
       PRE = nil unless defined? PRE
 
       class << self


### PR DESCRIPTION
Hi there. I use fog-azure-rm to upload images to azure blob storage which uses azure-core gem. So now I started updating my app to Rails 6 and found that rails uses actiontext gem which uses nokogiri. And it's required version is >= 1.8.5.

https://github.com/Azure/azure-ruby-asm-core/issues/67