### PR TITLE
Bump Nokogiri version

### DIFF
--- a/azure-core.gemspec
+++ b/azure-core.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('faraday',                 '~> 0.9')
   s.add_runtime_dependency('faraday_middleware',      '~> 0.10')
-  s.add_runtime_dependency('nokogiri',                '~> 1.6')
+  s.add_runtime_dependency('nokogiri',                '~> 1.10')
 
   s.add_development_dependency('dotenv',              '~> 2.0')
   s.add_development_dependency('minitest',            '~> 5')


### PR DESCRIPTION
Nokogiri had a serious security flaw that was fixed in 1.10.4
https://github.com/sparklemotion/nokogiri/issues/1915