### PR TITLE
Gemspec versions

### DIFF
--- a/azure-core.gemspec
+++ b/azure-core.gemspec
@@ -37,8 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('minitest',            '~> 5')
   s.add_development_dependency('minitest-reporters',  '~> 1')
   s.add_development_dependency('mocha',               '~> 1.0')
-  s.add_development_dependency('rake',                '~> 10.0')
+  s.add_development_dependency('rake')
   s.add_development_dependency('timecop',             '~> 0.7')
-  s.add_development_dependency('bundler',             '~> 1.11')
-
+  s.add_development_dependency('bundler')
 end

--- a/azure-core.gemspec
+++ b/azure-core.gemspec
@@ -29,8 +29,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency('faraday',                 '~> 0.9')
-  s.add_runtime_dependency('faraday_middleware',      '~> 0.10')
+  s.add_runtime_dependency('faraday',                 '~> 1.0')
+  s.add_runtime_dependency('faraday_middleware',      '~> 1.1')
   s.add_runtime_dependency('nokogiri',                '~> 1.6')
 
   s.add_development_dependency('dotenv',              '~> 2.0')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,7 +16,7 @@ require 'dotenv'
 Dotenv.load
 
 require 'minitest/autorun'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 require 'minitest/reporters'
 # Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 require 'timecop'


### PR DESCRIPTION
- fix test version of mocha so the tests can be run.
- upgrade the `faraday` and `faraday_middleware` gem references so code that depends upon `azure-core` can be upgraded as well.
- this has implications and I'm going through other azure gems to see that they are ok with this upgrade.

This PR overlaps with https://github.com/Azure/azure-ruby-asm-core/pull/71 but most importantly, upgrades to a version middleware that is compatible with the new `faraday`.

Thanks for all your help